### PR TITLE
Devhops demo code updates

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -84,6 +84,8 @@ mod 'jdowning-rbenv', '2.2.0'
 mod 'puppet-windows_env', '2.3.0'
 mod 'camptocamp-systemd', '1.1.0'
 
+mod 'puppetlabs-wsus_client', :latest
+
 mod 'tse-tse_facts',
   :git => 'https://github.com/puppetlabs/tse-module-tse_facts.git'
 

--- a/site/profile/manifests/platform/baseline/windows/wsus.pp
+++ b/site/profile/manifests/platform/baseline/windows/wsus.pp
@@ -1,0 +1,14 @@
+
+  # Obligatory comment
+  class profile::platform::baseline::windows::wsus {
+
+    # Enforce Windows Update to run every Sunday.
+    class { 'wsus_client':
+            server_url             => 'http://wsus:8530',
+            auto_update_option     => 'Scheduled',
+            scheduled_install_day  => 'Sunday',
+            scheduled_install_hour => 2,
+            enable_status_server   => true,
+    }
+
+  }

--- a/site/profile/manifests/platform/demo.pp
+++ b/site/profile/manifests/platform/demo.pp
@@ -13,5 +13,4 @@ class profile::platform::demo {
       fail('Unsupported operating system!')
     }
   }
-
 }

--- a/site/profile/manifests/platform/demo/windows.pp
+++ b/site/profile/manifests/platform/demo/windows.pp
@@ -1,6 +1,6 @@
 # Windows DEMO Profiles
 class profile::platform::demo::windows {
-    # Various DSC Type operations.
+  # Various DSC Type operations.
   include ::profile::platform::demo::windows::dsc::dscaddreg
   include ::profile::platform::demo::windows::dsc::dscfile
   include ::profile::platform::demo::windows::dsc::dscfirewall
@@ -10,6 +10,4 @@ class profile::platform::demo::windows {
   include ::profile::platform::demo::windows::users::demousers
   # Set the power configuration.
   include ::profile::platform::demo::windows::power::power
-  # Install Process Explorer utility.
-  include ::profile::platform::demo::windows::util::processexplorer
 }

--- a/site/profile/manifests/platform/demo/windows/dsc/dscaddreg.pp
+++ b/site/profile/manifests/platform/demo/windows/dsc/dscaddreg.pp
@@ -1,5 +1,5 @@
-
-class profile::dsc::dscaddreg {
+#
+class profile::platform::demo::windows::dsc::dscaddreg {
   # requires registry module for Puppet
   dsc_registry { 'registry_test_binary':
     dsc_ensure    => 'Present',
@@ -21,7 +21,7 @@ class profile::dsc::dscaddreg {
     dsc_ensure    => 'Present',
     dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\PuppetDSCDemo',
     dsc_valuename => 'Dsc_TestStringValue',
-    dsc_valuedata => 'WinOps 2017 Demonstration (DSC)',
+    dsc_valuedata => 'DevHops Demonstration (DSC)',
     dsc_valuetype => 'String',
   }
 }

--- a/site/profile/manifests/platform/demo/windows/dsc/dscfile.pp
+++ b/site/profile/manifests/platform/demo/windows/dsc/dscfile.pp
@@ -1,11 +1,12 @@
-class profile::dsc::dscfile {
+#
+class profile::platform::demo::windows::dsc::dscfile {
 
-  $test_file_contents = 'This file is installed on Desktop for WinOps 2017 Puppet Demo'
+  $test_file_contents = 'This file is installed on Desktop for DevHops 2018 Puppet Demo'
 
   dsc_file {'demo_file':
     dsc_ensure          => 'present',
     dsc_type            => 'File',
-    dsc_destinationpath => 'C:/Users/puppet/Desktop/WinOps2017-Demo.txt',
+    dsc_destinationpath => 'C:/Users/Administrator/Desktop/DevHops2018-Demo.txt',
     dsc_contents        => $test_file_contents,
 
     # DSC specific properties

--- a/site/profile/manifests/platform/demo/windows/dsc/dscfirewall.pp
+++ b/site/profile/manifests/platform/demo/windows/dsc/dscfirewall.pp
@@ -1,12 +1,13 @@
-class profile::dsc::dscfirewall {
+#
+class profile::platform::demo::windows::dsc::dscfirewall {
 
   dsc_xFirewall { 'inbound-2222':
-    dsc_ensure => 'present',
-    dsc_name => 'inbound2222',
-    dsc_displayname => 'Inbound DSC 2222 Test',
+    dsc_ensure       => 'present',
+    dsc_name         => 'inbound2222',
+    dsc_displayname  => 'Inbound DSC 2222 Test',
     dsc_displaygroup => 'A Puppet + DSC Test',
-    dsc_action => 'Allow',
-    dsc_enabled => 'False',
-    dsc_direction => 'Inbound',
+    dsc_action       => 'Allow',
+    dsc_enabled      => 'False',
+    dsc_direction    => 'Inbound',
   }
 }

--- a/site/profile/manifests/platform/demo/windows/power/power.pp
+++ b/site/profile/manifests/platform/demo/windows/power/power.pp
@@ -1,4 +1,5 @@
-class profile::power::power (
+#
+class profile::platform::demo::windows::power::power (
   $scheme = 'powersaver',
 ) {
   $guid = $scheme ? {

--- a/site/profile/manifests/platform/demo/windows/registry/regentries.pp
+++ b/site/profile/manifests/platform/demo/windows/registry/regentries.pp
@@ -1,4 +1,5 @@
-class profile::registry::regentries {
+#
+class profile::platform::demo::windows::registry::regentries {
 
   registry::value { 'registry_test_binary':
       key   => 'HKEY_LOCAL_MACHINE\SOFTWARE\PuppetRegDemo',
@@ -17,7 +18,7 @@ class profile::registry::regentries {
   registry::value { 'registry_test_string':
       key   => 'HKEY_LOCAL_MACHINE\SOFTWARE\PuppetRegDemo',
       value => 'Reg_TestStringValue',
-      data  => 'WinOps 2017 Demonstration',
+      data  => 'DevHops Demonstration',
       type  => 'string'
   }
 }

--- a/site/profile/manifests/platform/demo/windows/users/demousers.pp
+++ b/site/profile/manifests/platform/demo/windows/users/demousers.pp
@@ -1,22 +1,22 @@
 #
-class profile::users::demousers {
+class profile::platform::demo::windows::users::demousers {
 
-  user { 'winopsdemo_1':
+  user { 'DevHopsdemo_1':
     # on Windows can use username, domain\user and SID
-    name                 => 'WinOps DemoUser 1',
-    ensure               => present,
-    managehome           => true,
-    password             => 'GarbledPasswd!',
-    groups               => ['Administrators', 'Users']
+    ensure     => present,
+    name       => 'DevHops DemoUser 1',
+    managehome => true,
+    password   => 'GarbledPasswd!',
+    groups     => ['Administrators', 'Users']
   }
 
-  user { 'winopsdemo_2':
+  user { 'DevHopsdemo_2':
     # on Windows can use username, domain\user and SID
-    name                 => 'WinOps DemoUser 2',
-    ensure               => present,
-    managehome           => true,
-    password             => 'GarbledPasswd!',
-    groups               => ['Administrators', 'Users']
+    ensure     => present,
+    name       => 'DevHops DemoUser 2',
+    managehome => true,
+    password   => 'GarbledPasswd!',
+    groups     => ['Administrators', 'Users']
   }
 
 }

--- a/site/role/manifests/devhops_demo.pp
+++ b/site/role/manifests/devhops_demo.pp
@@ -4,5 +4,4 @@
 class role::devhops_demo {
   include ::profile::platform::baseline
   include ::profile::platform::demo
-
 }


### PR DESCRIPTION
Updating main control repo with fixes that were used in the PE/Windows
demo at the London DevHops event.

Also add in a WSUS profile in case we want to use it.