### PR TITLE
(DEVHOPS-1) Add WSUS Profile to baseline.

### DIFF
--- a/site/profile/manifests/platform/baseline/windows.pp
+++ b/site/profile/manifests/platform/baseline/windows.pp
@@ -6,5 +6,7 @@ class profile::platform::baseline::windows {
   include ::profile::platform::baseline::windows::firewall
   include ::profile::platform::baseline::windows::packages
   include ::profile::platform::baseline::users::windows
+  include ::profile::platform::baseline::windows::wsus
+
 
 }


### PR DESCRIPTION
The WSUS Profile is missing from Baseline, so add it.